### PR TITLE
Add Django migrations.

### DIFF
--- a/django_lti_tool_provider/migrations/0001_initial.py
+++ b/django_lti_tool_provider/migrations/0001_initial.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import jsonfield.fields
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='LtiUserData',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('edx_lti_parameters', jsonfield.fields.JSONField(default={})),
+                ('custom_key', models.CharField(default=b'', max_length=400)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+        migrations.AlterUniqueTogether(
+            name='ltiuserdata',
+            unique_together=set([('user', 'custom_key')]),
+        ),
+    ]


### PR DESCRIPTION
This app contains a dependency on a migrated app, namely django.contrib.auth.
Unmigrated apps can't depend on migrated apps, making it impossible to recreate
the database in anything that depends on this app (and hence impossible to run
any tests).
