### PR TITLE
Changed length of LtiUserData.custom_key so we work around 767 keysize restriction on mysql.

### DIFF
--- a/django_lti_tool_provider/migrations/0001_initial.py
+++ b/django_lti_tool_provider/migrations/0001_initial.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('edx_lti_parameters', jsonfield.fields.JSONField(default={})),
-                ('custom_key', models.CharField(default=b'', max_length=400)),
+                ('custom_key', models.CharField(default=b'', max_length=190)),
                 ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
             ],
         ),

--- a/django_lti_tool_provider/models.py
+++ b/django_lti_tool_provider/models.py
@@ -18,7 +18,7 @@ class WrongUserError(Exception):
 class LtiUserData(models.Model):
     user = models.ForeignKey(User)
     edx_lti_parameters = JSONField(default={})
-    custom_key = models.CharField(max_length=400, null=False, default='')
+    custom_key = models.CharField(max_length=190, null=False, default='')
 
     class Meta:
         app_label = "django_lti_tool_provider"

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def package_data(pkg, root_list):
 # Main ##############################################################
 setup(
     name='django_lti_tool_provider',
-    version='0.1',
+    version='0.1.1',
     license="GNU AFFERO GENERAL PUBLIC LICENSE",
     description='IMS LTI Tool Provider Django Applocation',
     long_description=README,


### PR DESCRIPTION
Changed length of `LtiUserData.custom_key` so we work around 767 key-size restriction on mysql.

Change has been retro-actively back-ported to initial migration (initial migration wouldn't work without it). This shouln't break any existing instances --- existing instances will have longer rows, but they work already. 

Thanks to @smarnach for suggesting this change. 

@antoviaque This is part of the OC-1506. 
