### PR TITLE
Optional lti parameters

### DIFF
--- a/django_lti_tool_provider/__init__.py
+++ b/django_lti_tool_provider/__init__.py
@@ -11,7 +11,7 @@ logging.getLogger("").addHandler(logging.NullHandler())
 class AbstractApplicationHookManager(object):
     """ Class that performs authentication and redirection for LTI views """
     @abstractmethod
-    def authentication_hook(self, request, user_id=None, username=None, email=None):
+    def authentication_hook(self, request, user_id=None, username=None, email=None, **kwargs):
         """ Hook to authenticate user from data available in LTI request """
 
     @abstractmethod
@@ -39,3 +39,18 @@ class AbstractApplicationHookManager(object):
         ordinary field.
         """
         return None
+
+    def optional_lti_parameters(self):
+        """
+        Return a dictionary of LTI parameters supported/required by this AuthenticationHookManager in addition
+        to user_id, username and email. These parameters are passed to authentication_hook method via kwargs.
+
+        This dictionary should have LTI parameter names (as specified by LTI specification) as keys; values are used
+        as parameter names passed to authentication_hook method, i.e. it allows renaming (not always intuitive) LTI spec
+        parameter names.
+
+        Example:
+            # renames lis_person_name_given -> user_first_name, lis_person_name_family -> user_lat_name
+            {'lis_person_name_given': 'user_first_name', 'lis_person_name_family': 'user_lat_name'}
+        """
+        return {}

--- a/django_lti_tool_provider/__init__.py
+++ b/django_lti_tool_provider/__init__.py
@@ -7,6 +7,9 @@ from six import add_metaclass
 logging.getLogger("").addHandler(logging.NullHandler())
 
 
+# pylint: disable=unused-argument
+# This class specifies method signatures; while pylint is intelligent enough to ignore unused args in abstractmethods
+# methods with default implementations are still reported. Hence we suppress unused-argument for entire class
 @add_metaclass(ABCMeta)
 class AbstractApplicationHookManager(object):
     """ Class that performs authentication and redirection for LTI views """

--- a/django_lti_tool_provider/__init__.py
+++ b/django_lti_tool_provider/__init__.py
@@ -14,7 +14,7 @@ logging.getLogger("").addHandler(logging.NullHandler())
 class AbstractApplicationHookManager(object):
     """ Class that performs authentication and redirection for LTI views """
     @abstractmethod
-    def authentication_hook(self, request, user_id=None, username=None, email=None, **kwargs):
+    def authentication_hook(self, request, user_id=None, username=None, email=None, extra_params=None):
         """ Hook to authenticate user from data available in LTI request """
 
     @abstractmethod

--- a/django_lti_tool_provider/models.py
+++ b/django_lti_tool_provider/models.py
@@ -56,9 +56,10 @@ class LtiUserData(models.Model):
         provider = DjangoToolProvider(settings.LTI_CLIENT_KEY, settings.LTI_CLIENT_SECRET, self.edx_lti_parameters)
         outcome = provider.post_replace_result(grade)
 
-        _logger.info(u"LTI grade request was {successful}. Description is {description}".format(
-            successful="successful" if outcome.is_success() else "unsuccessful", description=outcome.description
-        ))
+        _logger.info(
+            u"LTI grade request was %(successful)s. Description is %(description)s",
+            dict(successful="successful" if outcome.is_success() else "unsuccessful", description=outcome.description)
+        )
 
         return outcome
 
@@ -103,3 +104,8 @@ class LtiUserData(models.Model):
             _logger.debug(u"Replaced LTI parameters for user %s", user.username)
         lti_user_data.save()
         return lti_user_data
+
+    def __unicode__(self):
+        return u"{classname} for {user} and (vary_key: {custom_key})".format(
+            classname=self.__class__.__name__, user=self.user, custom_key=self.custom_key
+        )

--- a/django_lti_tool_provider/signals.py
+++ b/django_lti_tool_provider/signals.py
@@ -17,7 +17,7 @@ class Signals(object):
 
 
 @receiver(Signals.Grade.updated, dispatch_uid="django_lti_grade_updated")
-def grade_updated_handler(sender, **kwargs):
+def grade_updated_handler(sender, **kwargs):  # pylint: disable=unused-argument
     user = kwargs.get('user', None)
     grade = kwargs.get('grade', None)
     custom_key = kwargs.get('custom_key', None)
@@ -32,14 +32,13 @@ def _send_grade(user, grade, custom_key):
         lti_user_data.send_lti_grade(grade)
     except LtiUserData.DoesNotExist:
         _logger.info(
-            u"No LTI parameters for user {user} and key {key} stored - probably never sent an LTI request"
-            .format(user=user.username, key=custom_key)
+            u"No LTI parameters for user %(user)s and key %(key)s stored - probably never sent an LTI request",
+            dict(user=user.username, key=custom_key)
         )
         raise
-    except Exception:  # pylint:disable=too-broad-exception
+    except Exception:
         _logger.exception(
-            u"Exception occurred in lti module when sending grade for user {user} and key {key}.".format(
-                user=user, key=custom_key
-            )
+            u"Exception occurred in lti module when sending grade for user %(user)s and key %(key)s.",
+            dict(user=user, key=custom_key)
         )
         raise

--- a/django_lti_tool_provider/tests/test_views.py
+++ b/django_lti_tool_provider/tests/test_views.py
@@ -231,6 +231,7 @@ class AuthenticationManagerIntegrationTests(LtiRequestsTestBase):
             'username': self._data['lis_person_sourcedid'],
             'email': self._data['lis_person_contact_email_primary'],
             'user_id': self._data['user_id'],
+            'extra_params': {}
         }
         self.assertEqual(user_data, expected_user_data)
 
@@ -246,8 +247,10 @@ class AuthenticationManagerIntegrationTests(LtiRequestsTestBase):
             'username': self._data['lis_person_sourcedid'],
             'email': self._data['lis_person_contact_email_primary'],
             'user_id': self._data['user_id'],
-            'link_id': 'resource_link_id',
-            'roles': ['Student']
+            'extra_params': {
+                'roles': ['Student'],
+                'link_id': 'resource_link_id',
+            }
         }
         self.assertEqual(user_data, expected_user_data)
 

--- a/django_lti_tool_provider/urls.py
+++ b/django_lti_tool_provider/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from django_lti_tool_provider import views as lti_views
 

--- a/django_lti_tool_provider/views.py
+++ b/django_lti_tool_provider/views.py
@@ -62,9 +62,14 @@ class LTIView(View):
                 _logger.exception(u"Invalid LTI Request")
                 return HttpResponseBadRequest(u"Invalid LTI Request: " + e.message)
 
+            lti_parameters_mapping = self.PASS_TO_AUTHENTICATION_HOOK.copy()
+            optional_lti_parameters = self.authentication_manager.optional_lti_parameters()
+            if optional_lti_parameters:
+                lti_parameters_mapping.update(optional_lti_parameters)
+
             lti_data = {
                 hook_name: lti_parameters.get(lti_name, None)
-                for lti_name, hook_name in self.PASS_TO_AUTHENTICATION_HOOK.items()
+                for lti_name, hook_name in lti_parameters_mapping.iteritems()
             }
 
             _logger.debug(u"Executing authentication hook with parameters {params}", lti_data)

--- a/django_lti_tool_provider/views.py
+++ b/django_lti_tool_provider/views.py
@@ -63,13 +63,15 @@ class LTIView(View):
                 return HttpResponseBadRequest(u"Invalid LTI Request: " + e.message)
 
             lti_parameters_mapping = self.PASS_TO_AUTHENTICATION_HOOK.copy()
-            optional_lti_parameters = self.authentication_manager.optional_lti_parameters()
-            if optional_lti_parameters:
-                lti_parameters_mapping.update(optional_lti_parameters)
 
             lti_data = {
                 hook_name: lti_parameters.get(lti_name, None)
                 for lti_name, hook_name in lti_parameters_mapping.iteritems()
+            }
+
+            lti_data['extra_params'] = {
+                hook_name: lti_parameters.get(lti_name, None)
+                for lti_name, hook_name in self.authentication_manager.optional_lti_parameters().iteritems()
             }
 
             _logger.debug(u"Executing authentication hook with parameters %s", lti_data)

--- a/django_lti_tool_provider/views.py
+++ b/django_lti_tool_provider/views.py
@@ -72,7 +72,7 @@ class LTIView(View):
                 for lti_name, hook_name in lti_parameters_mapping.iteritems()
             }
 
-            _logger.debug(u"Executing authentication hook with parameters {params}", lti_data)
+            _logger.debug(u"Executing authentication hook with parameters %s", lti_data)
 
             self.authentication_manager.authentication_hook(request, **lti_data)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ six
 # test requirements
 mock
 ddt
+prospector

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def package_data(pkg, root_list):
 # Main ##############################################################
 setup(
     name='django_lti_tool_provider',
-    version='0.1.1',
+    version='0.1.2',
     license="GNU AFFERO GENERAL PUBLIC LICENSE",
     description='IMS LTI Tool Provider Django Applocation',
     long_description=README,


### PR DESCRIPTION
**Description:** Allows AuthenticationHookManager classes accept and request additional LTI parameters.

**Testing Instructions:** Part of two-PR changeset, instructions are given on the [other one](https://github.com/open-craft/dalite-ng/pull/50).
