### PR TITLE
Adding custom key length migration

### DIFF
--- a/django_lti_tool_provider/migrations/0002_reduce_custom_key_length.py
+++ b/django_lti_tool_provider/migrations/0002_reduce_custom_key_length.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.db.models import Max
+from django.db.models.functions import Length
+
+def check_field_max_length_lteq_190(apps, schema_editor):
+    """
+    Check to see if we've got any data in the table that prevents us from
+    migrating the length of the column down to 190; if so, raise an exception.
+    """
+    LtiUserData = apps.get_model('django_lti_tool_provider', 'LtiUserData')
+    max_custom_key_length = LtiUserData.objects.aggregate(length=Max(Length('custom_key')))['length']
+    if max_custom_key_length > 190:
+        raise ValueError('Cannot perform migration: values of \'custom_key\' with length '
+                         '{} exceed the expected length 190.'.format(max_custom_key_length))
+
+
+class Migration(migrations.Migration):
+    """
+    Note that this migration is a no-op for instances created using the current
+    state of the initial migration. However, a previous version of the initial
+    migration set the maximum length of 'LtiUserData.custom_key' to 400, which is
+    longer than allowed for a MySQL 5.5 CharField. Thus, this migration is intended
+    to bring databases set up by the previous version of the initial migration
+    into parity with databases set up by the current version.
+    """
+
+    dependencies = [
+        ('django_lti_tool_provider', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=check_field_max_length_lteq_190
+        ),
+        migrations.RunSQL(
+            sql=migrations.RunSQL.noop,
+            state_operations=[
+                # This is a shim. Django is oh-so-efficient, so if it detects
+                # that the database should be in a state based on previous migrations,
+                # it won't perform the operations to move to that state. This tells
+                # Django "hey, I'm in this different state" without actually modifying
+                # the database. This is not a reversible operation.
+                migrations.AlterField(
+                    model_name='ltiuserdata',
+                    name='custom_key',
+                    field=models.CharField(default=b'', max_length=400)
+                )
+            ],
+        ),
+        migrations.AlterField(
+            model_name='ltiuserdata',
+            name='custom_key',
+            field=models.CharField(default=b'', max_length=190),
+        ),
+    ]

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def package_data(pkg, root_list):
 # Main ##############################################################
 setup(
     name='django_lti_tool_provider',
-    version='0.1.2',
+    version='0.1.3',
     license="GNU AFFERO GENERAL PUBLIC LICENSE",
     description='IMS LTI Tool Provider Django Applocation',
     long_description=README,


### PR DESCRIPTION
In #6, we modified the initial migration to work around a MySQL field length issue, which means that our installed base doesn't necessarily have a database in step with what Django might think it should. Migration 0002 solves that by migrating databases with the original 400-character length `custom_key` field on the `LtiUserData` model to the 190-character length newer deploys have, failing if there are entries over that length (databases don't treat this consistently while migrating, so we want an explicit check and failure condition).

It's hard to test, as new deploys now necessarily initially create a database with length of 190, but I did manually test this migration by checking it out as a modification from 190 down to 100- it failed when there were entries over 100 characters in length, and succeeded otherwise.

**Reviewers**
- [ ] @bradenmacdonald 
